### PR TITLE
fix error 'IndexError: list index out of range' due to variable list *inputs not properly handled in bundle.py

### DIFF
--- a/opto/trace/bundle.py
+++ b/opto/trace/bundle.py
@@ -223,7 +223,7 @@ class FunModule(Module):
         # convert args and kwargs to nodes, except for FunModule
         _args, _kwargs = args, kwargs  # back up
 
-        args = [node(a, name=fullargspec.args[i] if not isinstance(a, Node) else None) if not isinstance(a, FunModule) else a for i, a in enumerate(args)]
+        args = [node(a, name=fullargspec.args[i] if i < len(fullargspec.args) and not isinstance(a, Node) else None) if not isinstance(a, FunModule) else a for i, a in enumerate(args)]
         kwargs = {k: node(v, name=k if not isinstance(v, Node) else None) if not isinstance(v, FunModule) else v for k, v in kwargs.items()}
 
         ## Construct the input dict of the MessageNode from function inputs


### PR DESCRIPTION
Functions using "*inputs" like in textgrad_prompt_optimization.ipynb would crash with error "IndexError: list index out of range" 
```python
@trace.bundle()
def query(system_prompt, *inputs):
    """ Query the language model with the system prompt and the input query """
    return tg.BlackboxLLM(llm_api_test, system_prompt)(*inputs)
```

It could be fixed by setting a fixed parameter:
```python
@trace.bundle()
def query(system_prompt, x):
    """ Query the language model with the system prompt and the input query """
    return tg.BlackboxLLM(llm_api_test, system_prompt)(x)
```

However, a more permanent fix is the following modification in bundle.py to safely handles functions with any number of positional arguments, including those using *inputs