### PR TITLE
Fix TypeError in response handling with f-string formatting for suggestion values

### DIFF
--- a/opto/trace/utils.py
+++ b/opto/trace/utils.py
@@ -67,13 +67,11 @@ def render_opt_step(step_idx, optimizer, no_trace_graph=False, no_improvement=Fa
     llm_response = json.loads(optimizer.log[idx]['response'])
     r1 = llm_response['reasoning']
 
-    if 'suggestion' in llm_response and llm_response['suggestion'] is not None:
-        a1 = ""
-        for var_name, var_body in llm_response['suggestion'].items():
-            a1 += var_name + ':\n\n'
-            a1 += var_body + '\n\n'
-
-    elif 'answer' in llm_response and llm_response['answer'] is not None:
+    if llm_response.get('suggestion'):
+        a1 = ''.join(
+            [f"{var_name}:\n\n{var_body}\n\n" for var_name, var_body in llm_response['suggestion'].items()]
+        )
+    elif llm_response.get('answer') is not None:
         a1 = llm_response['answer']
     else:
         a1 = "<ERROR> NULL/INVALID RESPONSE"


### PR DESCRIPTION
This pull request addresses a `TypeError` encountered when concatenating a string with non-string values (such as integers) in the response processing logic. The issue was fixed by using f-string formatting to properly handle different data types in the suggestion values. This ensures that both `int` and `str` types are correctly converted to strings for concatenation. 

Changes include:
- Replaced manual string concatenation with f-strings for better handling of variable types.
- Improved the readability and maintainability of the code by using a list comprehension for constructing the formatted response.

This fix ensures that the response handling logic works correctly even when `var_body` is an integer or other non-string type.
