### PR TITLE
Fix SyntaxWarning: invalid escape sequence '\/'

### DIFF
--- a/opto/trace/utils.py
+++ b/opto/trace/utils.py
@@ -219,7 +219,7 @@ def escape_json_nested_quotes(json_str):
             # we didn't add \u to this list
             if json_str[i - 1] == "\\" and char not in [
                 "\\",
-                "\/",
+                "\\/",
                 "n",
                 "b",
                 "f",


### PR DESCRIPTION
Small fix for invalid escape sequence in escape_json_nested_quotes 